### PR TITLE
LPD-41509 Revert "LPD-37385 Use template literal and use native Intl.…

### DIFF
--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -124,20 +124,14 @@ test(
 
 		await expect(toastAlertContainer).toBeVisible();
 
-		await expect(toastAlertContainer).toHaveText(
-			`Success:${title} will be published on ${new Intl.DateTimeFormat(
-				'en-US',
-				{
-					day: 'numeric',
-					hour: 'numeric',
-					hour12: true,
-					minute: 'numeric',
-					month: 'numeric',
-					year: '2-digit',
-				}
-			)
-				.format(new Date(scheduleDate))
-				.replace(',', '')}.`
+		await expect(toastAlertContainer).toContainText(`Success:${title}`);
+
+		await expect(toastAlertContainer).toContainText(
+			new Intl.DateTimeFormat('en-US', {
+				day: 'numeric',
+				month: 'numeric',
+				year: '2-digit',
+			}).format(new Date(scheduleDate))
 		);
 	}
 );


### PR DESCRIPTION
…DateTimeFormat instead of moment"

This reverts commit c036b580ea4964725ec3f34bd419b46a7907e903.